### PR TITLE
Fix Netlify Identity email clickthrough handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ export default function (Vue, { router, head, isClient }) {
     if (hash) {
       return global.location.replace(`/admin#${hash}`)
     }
-    next();
+    next()
   })
 
   // Set default layout as a global component

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,16 @@ import DefaultLayout from '~/layouts/Default.vue'
 
 // The Client API can be used here. Learn more: gridsome.org/docs/client-api
 export default function (Vue, { router, head, isClient }) {
-  
+
+  router.beforeEach((to, from, next) => {
+    const { hash } = to
+    if (hash) {
+      return global.location.replace(`/admin#${hash}`)
+    }
+    next();
+  })
+
   // Set default layout as a global component
   Vue.component('Layout', DefaultLayout)
 }
+


### PR DESCRIPTION
This PR addresses two issues related to Netlify Identity. Specifically: 

1. Users who click the *Accept Invitation* link that appears in Netlify Identity invitation emails are unable to actually accept the invitation.

The invitation link in these emails ultimately redirect to: 
```
https://DOMAIN/#invite_token=TOKEN
```

2. Similarly, users who click the *Reset password* link that appears in Netlify Identity reset password emails are not able to actually reset their password.

The reset password link in these emails ultimately redirect to:
```
https://DOMAIN/#recovery_token=TOKEN
```

*Problem*

In both cases the URL contains a hash with an opaque base 62 token. The  hash is supposed to be detected and handled by the Netlify CMS admin script served by `/admin`. Currently there is no handling around these URL hashes within this project template.

*Proposed Solution*

Add a `beforeEach` route guard to the `router` instance exposed by `src/main.js`. If a hash is detected in the `to` route, navigate the browser via `location.replace` to `/admin` while preserving the hash.
 
Obviously this solution is incompatible with projects that configure their `vue-router` to use hash-based routing. But all modern browsers support the HTML5 History API now, so I think this is an acceptable workaround.
