### PR TITLE
Fix images to properly create g-image components

### DIFF
--- a/content/posts/a-post-with-a-cover.md
+++ b/content/posts/a-post-with-a-cover.md
@@ -5,7 +5,7 @@ published: true
 tags:
   - Markdown
   - Cover Image
-cover_image: /images/uploads/alexandr-podvalny-220262-unsplash.jpg
+cover_image: ../../static/images/uploads/alexandr-podvalny-220262-unsplash.jpg
 description: >-
   Markdown is intended to be as easy-to-read and easy-to-write as is feasible.
   Readability, however, is emphasized above all else. A Markdown-formatted

--- a/content/posts/another-image-test.md
+++ b/content/posts/another-image-test.md
@@ -6,7 +6,7 @@ tags:
   - markdown
   - image
   - test
-cover_image: /images/uploads/sun-3713835_1920.jpg
+cover_image: ../../static/images/uploads/sun-3713835_1920.jpg
 description: I am trying some image uploads.
 ---
 And I also write something down.

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -6,6 +6,9 @@ public_folder: "/images/uploads" # The src attribute for uploaded media will beg
 collections:
   - name: "posts" # Used in routes, e.g., /admin/collections/blog
     label: "Posts" # Used in the UI
+    folder: "content/posts"
+    media_folder: '/static/images/uploads'
+    public_folder: '../../static/images/uploads'
     folder: "content/posts" # The path to the folder where the documents are stored
     create: true # Allow users to create new documents in this collection
     slug: "{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -6,7 +6,6 @@ public_folder: "/images/uploads" # The src attribute for uploaded media will beg
 collections:
   - name: "posts" # Used in routes, e.g., /admin/collections/blog
     label: "Posts" # Used in the UI
-    folder: "content/posts"
     media_folder: '/static/images/uploads'
     public_folder: '../../static/images/uploads'
     folder: "content/posts" # The path to the folder where the documents are stored


### PR DESCRIPTION
Noticed in the starter site the images are plain old single `<img>` tags.

```
<img alt="Cover image" src="/images/uploads/sun-3713835_1920.jpg" class="post-card__image g-image">
```

![image](https://user-images.githubusercontent.com/628166/86438869-b2031f00-bd4a-11ea-87a9-9d71801e3b72.png)

After these changes:

```
<div class="post-card__header"><img alt="Cover image" src="/assets/static/sun-3713835_1920.81b85c1.d20ee42ad83e81611d99389b4b982ab3.jpg" data-src="/assets/static/sun-3713835_1920.81b85c1.d20ee42ad83e81611d99389b4b982ab3.jpg" data-srcset="/assets/static/sun-3713835_1920.81b85c1.d20ee42ad83e81611d99389b4b982ab3.jpg 770w" data-sizes="(max-width: 770px) 100vw, 770px" class="post-card__image g-image g-image--lazy g-image--loaded" srcset="/assets/static/sun-3713835_1920.81b85c1.d20ee42ad83e81611d99389b4b982ab3.jpg 770w" sizes="(max-width: 770px) 100vw, 770px" width="770"><noscript><img src="/assets/static/sun-3713835_1920.81b85c1.d20ee42ad83e81611d99389b4b982ab3.jpg" class="post-card__image g-image g-image--loaded" width="770" alt="Cover image"></noscript></div>
```

Lazy loading and all that now working.

The image paths look super messy with the `../../static` but I cant find a better solution for now.